### PR TITLE
Do not call validate_required when casting to ad-hoc Ecto schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## Unreleased
-
+  
+  * Fix `consume_response/3` enforcing all keys to present for ad-hoc Ecto schemas
   * Add Local Development Guide
 
 ## v0.1.0

--- a/lib/instructor_lite.ex
+++ b/lib/instructor_lite.ex
@@ -197,9 +197,7 @@ defmodule InstructorLite do
   def cast({data, types}, params) do
     fields = Map.keys(types)
 
-    {data, types}
-    |> Ecto.Changeset.cast(params, fields)
-    |> Ecto.Changeset.validate_required(fields)
+    Ecto.Changeset.cast({data, types}, params, fields)
   end
 
   def cast(%response_model{} = data, params) do

--- a/test/instructor_lite_test.exs
+++ b/test/instructor_lite_test.exs
@@ -290,10 +290,11 @@ defmodule InstructorLiteTest do
 
   describe "cast/2" do
     test "adhoc schema" do
-      model = {%{}, %{name: :string}}
+      model = {%{}, %{name: :string, age: :integer}}
       params = %{"name" => "foo"}
 
-      assert %Ecto.Changeset{changes: %{name: "foo"}} = InstructorLite.cast(model, params)
+      assert %Ecto.Changeset{changes: %{name: "foo"}, valid?: true} =
+               InstructorLite.cast(model, params)
     end
 
     test "actual schema" do


### PR DESCRIPTION
There is no reason why a key in response can't be nullable (in fact, OpenAI [explicitly supports it](https://platform.openai.com/docs/guides/structured-outputs/all-fields-must-be-required)), so we shouldn't require all fields. Users can always call `Ecto.Changeset.validate_required` in `validate_changeset/2` callback