### PR TITLE
Allow overriding response_format in OpenAI adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
   
+  * [OpenAI] Do not overwrite `response_format` params key if provided by user
   * Fix `consume_response/3` enforcing all keys to present for ad-hoc Ecto schemas
   * Add Local Development Guide
 

--- a/lib/instructor_lite/adapters/openai.ex
+++ b/lib/instructor_lite/adapters/openai.ex
@@ -4,6 +4,10 @@ defmodule InstructorLite.Adapters.OpenAI do
 
   This adapter is implemented using chat completions endpoint and [structured outputs](https://platform.openai.com/docs/guides/structured-outputs/structured-outputs).
 
+  > #### JSON mode {: .tip}
+  >
+  > Even though the adapter uses strict JSON Schema mode by default, it respects all explicitly provided keys in `params`. To switch to a less strict [JSON mode](https://platform.openai.com/docs/guides/structured-outputs/json-mode), simply provide the `response_format` key in your params.
+
   ## Params
   `params` argument should be shaped as a [Create chat completion request body](https://platform.openai.com/docs/api-reference/chat/create).
    
@@ -103,7 +107,7 @@ defmodule InstructorLite.Adapters.OpenAI do
 
     params
     |> Map.put_new(:model, @default_model)
-    |> Map.put(:response_format, %{
+    |> Map.put_new(:response_format, %{
       type: "json_schema",
       json_schema: %{
         name: "schema",

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -161,6 +161,39 @@ defmodule InstructorLite.IntegrationTest do
 
       assert {:ok, %{guess: :tails}} = result
     end
+
+    test "linked list" do
+      result =
+        InstructorLite.instruct(
+          %{
+            model: "gpt-4o-mini",
+            messages: [
+              %{
+                role: "user",
+                content: "Make a linked list of 3 elements"
+              }
+            ],
+            response_format: %{
+              type: "json_schema",
+              json_schema: %{
+                name: "schema",
+                strict: false,
+                schema: TestSchemas.LinkedList.json_schema()
+              }
+            }
+          },
+          response_model: TestSchemas.LinkedList,
+          max_retries: 1,
+          adapter: OpenAI,
+          adapter_context: [
+            http_client: Req,
+            api_key: Application.fetch_env!(:instructor_lite, :openai_key)
+          ],
+          extra: 3
+        )
+
+      assert {:ok, %{next: %{next: %{next: nil}}}} = result
+    end
   end
 
   describe "Anthropic" do
@@ -314,6 +347,30 @@ defmodule InstructorLite.IntegrationTest do
         )
 
       assert {:ok, %{guess: :tails}} = result
+    end
+
+    test "linked list" do
+      result =
+        InstructorLite.instruct(
+          %{
+            messages: [
+              %{
+                role: "user",
+                content: "Make a linked list of 3 elements"
+              }
+            ]
+          },
+          response_model: TestSchemas.LinkedList,
+          max_retries: 1,
+          adapter: Anthropic,
+          adapter_context: [
+            http_client: Req,
+            api_key: Application.fetch_env!(:instructor_lite, :anthropic_key)
+          ],
+          extra: 3
+        )
+
+      assert {:ok, %{next: %{next: %{next: nil}}}} = result
     end
   end
 

--- a/test/support/test_schemas.ex
+++ b/test/support/test_schemas.ex
@@ -91,19 +91,45 @@ defmodule InstructorLite.TestSchemas do
       embeds_one(:next, LinkedList)
     end
 
-    # @impl InstructorLite.Instruction
-    # def validate_changeset(cs, opts) do
-    #   max_items = Keyword.fetch!(opts, :max_list_items)
+    @impl InstructorLite.Instruction
+    def json_schema() do
+      %{
+        type: "object",
+        title: "LinkedList",
+        required: [:next, :value],
+        additionalProperties: false,
+        properties: %{
+          value: %{type: "integer"},
+          next: %{"$ref": "#/$defs/LinkedList"}
+        },
+        "$defs": %{
+          "LinkedList" => %{
+            type: ["object", "null"],
+            title: "LinkedList",
+            required: [:next, :value],
+            additionalProperties: false,
+            properties: %{
+              value: %{type: "integer"},
+              next: %{"$ref": "#/$defs/LinkedList"}
+            }
+          }
+        }
+      }
+    end
 
-    #   case do_validate(max_items, cs) do
-    #     :ok -> cs
-    #     :overflow -> Ecto.Changeset.add_error(cs, :next, "Too many items in the list!")
-    #   end
-    # end
+    @impl InstructorLite.Instruction
+    def validate_changeset(cs, opts) do
+      max_items = Keyword.fetch!(opts, :extra)
 
-    # defp do_validate(0, %{changes: %{next: %{}}}), do: :overflow
-    # defp do_validate(n, %{changes: %{next: %{} = next}}), do: do_validate(n - 1, next)
-    # defp do_validate(_, _), do: :ok
+      case do_validate(max_items, cs) do
+        :ok -> cs
+        :overflow -> Ecto.Changeset.add_error(cs, :next, "Too many items in the list!")
+      end
+    end
+
+    defp do_validate(0, %{changes: %{next: %{}}}), do: :overflow
+    defp do_validate(n, %{changes: %{next: %{} = next}}), do: do_validate(n - 1, next)
+    defp do_validate(_, _), do: :ok
   end
 
   defmodule CoinGuess do


### PR DESCRIPTION
Strict JSON Schema mode is great, but there are a couple of limitations that might make people want to use json mode instead. For example:
1. Images don't support structured output just yet
2. Even though OpenAI [explicitly supports](https://platform.openai.com/docs/guides/structured-outputs/all-fields-must-be-required) nullable keys through union type with `null`, it sometimes struggles to actually return null in strict mode. See linked list integration test