### PR TITLE
Introduce InstructorLite.ask/2

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.19.0-rc.0-otp-28
+elixir 1.18.4-otp-28
 erlang 28.0

--- a/lib/instructor_lite.ex
+++ b/lib/instructor_lite.ex
@@ -424,8 +424,12 @@ defmodule InstructorLite do
       |> Keyword.take(Keyword.keys(@ask_options))
       |> NimbleOptions.validate!(@ask_options_schema)
 
-    with {:ok, response} <- opts[:adapter].send_request(params, opts) do
-      opts[:adapter].find_output(response, opts)
+    if function_exported?(opts[:adapter], :find_output, 2) do
+      with {:ok, response} <- opts[:adapter].send_request(params, opts) do
+        opts[:adapter].find_output(response, opts)
+      end
+    else
+      raise "Can't use InstructorLite.ask/2 because #{inspect(opts[:adapter])}.find_output/2 is not implemented"
     end
   end
 

--- a/lib/instructor_lite/adapter.ex
+++ b/lib/instructor_lite/adapter.ex
@@ -66,4 +66,6 @@ defmodule InstructorLite.Adapter do
   @doc since: "1.1.0"
   @callback find_output(response(), InstructorLite.opts()) ::
               {:ok, String.t()} | {:error, any()} | {:error, reason :: atom(), any()}
+
+  @optional_callbacks [find_output: 2]
 end

--- a/lib/instructor_lite/adapter.ex
+++ b/lib/instructor_lite/adapter.ex
@@ -56,4 +56,14 @@ defmodule InstructorLite.Adapter do
   """
   @callback parse_response(response(), InstructorLite.opts()) ::
               {:ok, parsed_response()} | {:error, any()} | {:error, reason :: atom(), any()}
+
+  @doc """
+  Find text output in the response.
+
+  Similar to `parse_response/2`, but this callback assumes a simple plain text
+  response. Used in `InstructorLite.ask/2` function. 
+  """
+  @doc since: "1.1.0"
+  @callback find_output(response(), InstructorLite.opts()) ::
+              {:ok, String.t()} | {:error, any()} | {:error, reason :: atom(), any()}
 end

--- a/lib/instructor_lite/adapters/anthropic.ex
+++ b/lib/instructor_lite/adapters/anthropic.ex
@@ -156,4 +156,22 @@ defmodule InstructorLite.Adapters.Anthropic do
         {:error, :unexpected_response, other}
     end
   end
+
+  @doc """
+  Parse API response in search of plain text output.
+
+  Can return:
+    * `{:ok, text_output}` on success.
+    * `{:error, :unexpected_response, response}` if response is of unexpected shape.
+  """
+  @impl InstructorLite.Adapter
+  def find_output(response, _opts) do
+    case response do
+      %{"content" => [%{"text" => text}]} ->
+        {:ok, text}
+
+      other ->
+        {:error, :unexpected_response, other}
+    end
+  end
 end

--- a/lib/instructor_lite/adapters/llamacpp.ex
+++ b/lib/instructor_lite/adapters/llamacpp.ex
@@ -106,10 +106,24 @@ defmodule InstructorLite.Adapters.Llamacpp do
     * `{:error, :unexpected_response, response}` if response is of unexpected shape.
   """
   @impl InstructorLite.Adapter
-  def parse_response(response, _opts) do
+  def parse_response(response, opts) do
+    with {:ok, json} <- find_output(response, opts) do
+      InstructorLite.JSON.decode(json)
+    end
+  end
+
+  @doc """
+  Parse API response in search of plain text output.
+
+  Can return:
+    * `{:ok, text_output}` on success.
+    * `{:error, :unexpected_response, response}` if response is of unexpected shape.
+  """
+  @impl InstructorLite.Adapter
+  def find_output(response, _opts) do
     case response do
-      %{"content" => json} ->
-        InstructorLite.JSON.decode(json)
+      %{"content" => text} ->
+        {:ok, text}
 
       other ->
         {:error, :unexpected_response, other}

--- a/test/instructor_lite/adapters/anthropic_test.exs
+++ b/test/instructor_lite/adapters/anthropic_test.exs
@@ -184,4 +184,38 @@ defmodule InstructorLite.Adapters.AnthropicTest do
       assert {:error, :timeout} = Anthropic.send_request(%{}, opts)
     end
   end
+
+  describe "find_output/2" do
+    test "finds text output" do
+      response = %{
+        "content" => [%{"text" => "Washington", "type" => "text"}],
+        "id" => "msg_016zrCzBqd9Hvi4PHWNptfM6",
+        "model" => "claude-sonnet-4-20250514",
+        "role" => "assistant",
+        "stop_reason" => "end_turn",
+        "stop_sequence" => nil,
+        "type" => "message",
+        "usage" => %{
+          "cache_creation" => %{
+            "ephemeral_1h_input_tokens" => 0,
+            "ephemeral_5m_input_tokens" => 0
+          },
+          "cache_creation_input_tokens" => 0,
+          "cache_read_input_tokens" => 0,
+          "input_tokens" => 23,
+          "output_tokens" => 4,
+          "service_tier" => "standard"
+        }
+      }
+
+      assert {:ok, "Washington"} = Anthropic.find_output(response, [])
+    end
+
+    test "unexpected content" do
+      response = "Internal Server Error"
+
+      assert {:error, :unexpected_response, "Internal Server Error"} =
+               Anthropic.find_output(response, [])
+    end
+  end
 end

--- a/test/instructor_lite/adapters/llamacpp_test.exs
+++ b/test/instructor_lite/adapters/llamacpp_test.exs
@@ -121,4 +121,22 @@ defmodule InstructorLite.Adapters.LlamacppTest do
       assert {:error, :timeout} = Llamacpp.send_request(%{}, opts)
     end
   end
+
+  describe "find_output/2" do
+    test "finds output in the response" do
+      response = %{
+        "content" => "Washington"
+      }
+
+      assert {:ok, "Washington"} =
+               Llamacpp.find_output(response, [])
+    end
+
+    test "unexpected content" do
+      response = "Internal Server Error"
+
+      assert {:error, :unexpected_response, "Internal Server Error"} =
+               Llamacpp.find_output(response, [])
+    end
+  end
 end

--- a/test/instructor_lite_test.exs
+++ b/test/instructor_lite_test.exs
@@ -405,5 +405,21 @@ defmodule InstructorLiteTest do
 
       assert {:ok, "George Washington"} = InstructorLite.ask(params, options)
     end
+
+    test "raises if adapter doesn't implement find_output/2" do
+      assert_raise(
+        RuntimeError,
+        "Can't use InstructorLite.ask/2 because IncompleteAdapter.find_output/2 is not implemented",
+        fn ->
+          InstructorLite.ask(%{}, adapter: IncompleteAdapter)
+        end
+      )
+    end
+  end
+
+  test "pre-1.1.0 adapters don't throw warnings" do
+    refute ExUnit.CaptureIO.capture_io(:stderr, fn ->
+             Code.compile_file("test/support/incomplete_adapter.ex")
+           end) =~ "required by behaviour InstructorLite.Adapter is not implemented"
   end
 end

--- a/test/integration/anthropic_test.exs
+++ b/test/integration/anthropic_test.exs
@@ -207,5 +207,29 @@ defmodule InstructorLite.Integration.AnthropicTest do
       assert is_binary(name)
       assert %Date{} = birth_date
     end
+
+    test "simple call" do
+      result =
+        InstructorLite.ask(
+          %{
+            model: "claude-sonnet-4-20250514",
+            max_tokens: 10,
+            messages: [
+              %{
+                role: "user",
+                content:
+                  "Who was the first president of the USA? Answer with surname, single word."
+              }
+            ]
+          },
+          adapter: Anthropic,
+          adapter_context: [
+            http_client: Req,
+            api_key: Application.fetch_env!(:instructor_lite, :anthropic_key)
+          ]
+        )
+
+      assert {:ok, "Washington" <> _} = result
+    end
   end
 end

--- a/test/integration/gemini_test.exs
+++ b/test/integration/gemini_test.exs
@@ -183,5 +183,31 @@ defmodule InstructorLite.Integration.GeminiTest do
       assert is_binary(name)
       assert %Date{} = birth_date
     end
+
+    test "simple call" do
+      result =
+        InstructorLite.ask(
+          %{
+            contents: [
+              %{
+                role: "user",
+                parts: [
+                  %{
+                    text:
+                      "Who was the first president of the USA? Answer with surname, single word."
+                  }
+                ]
+              }
+            ]
+          },
+          adapter: Gemini,
+          adapter_context: [
+            http_client: Req,
+            api_key: Application.fetch_env!(:instructor_lite, :gemini_key)
+          ]
+        )
+
+      assert {:ok, "Washington" <> _} = result
+    end
   end
 end

--- a/test/integration/grok_test.exs
+++ b/test/integration/grok_test.exs
@@ -226,5 +226,30 @@ defmodule InstructorLite.Integration.GrokTest do
       assert is_binary(name)
       assert %Date{} = birth_date
     end
+
+    test "simple call" do
+      result =
+        InstructorLite.ask(
+          %{
+            model: "grok-3-latest",
+            messages: [
+              %{
+                role: "user",
+                content:
+                  "Who was the first president of the USA? Answer with surname, single word."
+              }
+            ]
+          },
+          max_retries: 1,
+          adapter: ChatCompletionsCompatible,
+          adapter_context: [
+            url: "https://api.x.ai/v1/chat/completions",
+            http_client: Req,
+            api_key: Application.fetch_env!(:instructor_lite, :grok_key)
+          ]
+        )
+
+      assert {:ok, "Washington" <> _} = result
+    end
   end
 end

--- a/test/integration/llamacpp_test.exs
+++ b/test/integration/llamacpp_test.exs
@@ -42,5 +42,19 @@ defmodule InstructorLite.Integration.LlamacppTest do
       assert {:ok, %{class: :spam, score: score}} = result
       assert is_float(score)
     end
+
+    test "simple call" do
+      result =
+        InstructorLite.ask(
+          %{prompt: "Who was the first president of the USA?"},
+          adapter: Llamacpp,
+          adapter_context: [
+            http_client: Req,
+            url: Application.fetch_env!(:instructor_lite, :llamacpp_url)
+          ]
+        )
+
+      assert {:ok, "Washington" <> _} = result
+    end
   end
 end

--- a/test/integration/openai_test.exs
+++ b/test/integration/openai_test.exs
@@ -243,6 +243,29 @@ defmodule InstructorLite.Integration.OpenAITest do
 
       assert {:ok, %{guess: :tails}} = result
     end
+
+    test "simple call" do
+      result =
+        InstructorLite.ask(
+          %{
+            model: "gpt-4o-mini",
+            input: [
+              %{
+                role: "user",
+                content:
+                  "Who was the first president of the USA? Answer with surname, single word."
+              }
+            ]
+          },
+          adapter: OpenAI,
+          adapter_context: [
+            http_client: Req,
+            api_key: Application.fetch_env!(:instructor_lite, :openai_key)
+          ]
+        )
+
+      assert {:ok, "Washington" <> _} = result
+    end
   end
 
   describe "ChatCompletionsCompatible adapter" do
@@ -455,6 +478,29 @@ defmodule InstructorLite.Integration.OpenAITest do
       assert {:ok, %{name: name, birth_date: birth_date}} = result
       assert is_binary(name)
       assert %Date{} = birth_date
+    end
+
+    test "simple call" do
+      result =
+        InstructorLite.ask(
+          %{
+            model: "gpt-4o-mini",
+            messages: [
+              %{
+                role: "user",
+                content:
+                  "Who was the first president of the USA? Answer with surname, single word."
+              }
+            ]
+          },
+          adapter: ChatCompletionsCompatible,
+          adapter_context: [
+            http_client: Req,
+            api_key: Application.fetch_env!(:instructor_lite, :openai_key)
+          ]
+        )
+
+      assert {:ok, "Washington" <> _} = result
     end
   end
 end

--- a/test/support/incomplete_adapter.ex
+++ b/test/support/incomplete_adapter.ex
@@ -1,0 +1,15 @@
+defmodule IncompleteAdapter do
+  @behaviour InstructorLite.Adapter
+
+  @impl true
+  def send_request(_params, _opts), do: {:error, :not_implemented}
+
+  @impl true
+  def initial_prompt(params, _opts), do: params
+
+  @impl true
+  def retry_prompt(params, _parsed_response, _errors, _response, _opts), do: params
+
+  @impl true
+  def parse_response(_response, _opts), do: {:error, :not_implemented}
+end


### PR DESCRIPTION
Inspired by https://github.com/martosaur/instructor_lite/issues/39

InstructorLite wants to be tinkering-friendly and that means making ad-hoc request with it should be fairly simple. One of the avenues to do that is to call adapters' callbacks directly. However, for simple requests for non-structured responses only `send_request/2` callback makes sense. `parse_response/2` assumes structured output and won't help much if it isn't. Which is a shame since in most cases the knowledge is already there in the adapter, just inaccessible to the public.

One way to address this would be to split `parse_response` callback into 2: for example `find_output` + `parse_output`. However, in general case structured and non-structured output may be in different places of the response. And this is indeed the case for Anthropic API for example.

This PR goes a slightly different route and introduces a new `find_output/2` callback which whole purpose is to find plain text output in the response. 

And since we have a new callback, we might as well use it and add a new `InstructorLite.ask/2` function to the library API.