### PR TITLE
Add automatic Gemini schema conversion from Ecto schemas

### DIFF
--- a/examples/demo.exs
+++ b/examples/demo.exs
@@ -1,0 +1,108 @@
+defmodule UserInfo do
+  use Ecto.Schema
+  use InstructorLite.Instruction
+
+  @primary_key false
+  embedded_schema do
+    field(:name, :string)
+    field(:age, :integer)
+  end
+end
+
+defmodule Demo do
+  def adapter(:openai), do: InstructorLite.Adapters.OpenAI
+  def adapter(:anthropic), do: InstructorLite.Adapters.Anthropic
+  def adapter(:gemini), do: InstructorLite.Adapters.Gemini
+
+  def messages(:openai, prompt), do: %{ input: [  %{role: "user", content: prompt} ] }
+  def messages(:anthropic, prompt), do: %{ messages: [  %{role: "user", content: prompt} ] }
+  def messages(:gemini, prompt), do: %{ contents: [  %{role: "user", parts: [%{text: prompt}]} ] }
+
+  def run_test(provider, model, config) do
+    prompt = "John Doe is forty-two years old"
+    expected = %UserInfo{name: "John Doe", age: 42}
+
+    start_time = System.monotonic_time(:millisecond)
+
+    result =
+        InstructorLite.instruct(
+          messages(provider, prompt) |> Map.put(:model, model),
+          response_model: UserInfo,
+          adapter: adapter(provider),
+          adapter_context: config
+        )
+
+    elapsed_ms = System.monotonic_time(:millisecond) - start_time
+
+    case result do
+      {:ok, ^expected} ->
+        IO.puts("✓ #{provider} #{model}: Correct (#{elapsed_ms}ms)")
+        {:correct, provider}
+
+      {:ok, other} ->
+        IO.puts("✗ #{provider} #{model}: Incorrect - Got #{inspect(other)} (#{elapsed_ms}ms)")
+        {:incorrect, other}
+
+      {:error, err} ->
+        IO.puts("✗ #{provider} #{model}: Error - #{inspect(err)} (#{elapsed_ms}ms)")
+        {:error, err}
+    end
+  end
+
+  def provider_configs do
+    [
+      %{
+        provider: :openai,
+        models: ["gpt-5", "gpt-5-mini", "gpt-5-nano", "gpt-4o-mini", "gpt-4o", "gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano"],
+        env_key: "OPENAI_API_KEY"
+      },
+      %{
+        provider: :anthropic,
+        models: ["claude-opus-4-1", "claude-opus-4-0", "claude-sonnet-4-0", "claude-3-7-sonnet-latest", "claude-3-5-haiku-20241022"],
+        env_key: "ANTHROPIC_API_KEY"
+      },
+      %{
+        provider: :gemini,
+        models: ["gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-image-preview", "gemini-live-2.5-flash-preview", "gemini-2.5-flash-preview-native-audio-dialog", "gemini-2.0-flash-exp", "gemini-1.5-flash", "gemini-1.5-pro"],
+        env_key: "GEMINI_API_KEY"
+      }
+    ]
+  end
+
+  def run_all_tests do
+    IO.puts("\nRunning InstructorLite Tests\n" <> String.duplicate("=", 30))
+
+    results = Enum.flat_map(provider_configs(), fn config ->
+      case System.get_env(config.env_key) do
+        nil ->
+          IO.puts("⚠ #{config.provider}: Skipped (#{config.env_key} not set)")
+          [{:skip, config.provider}]
+
+        api_key ->
+          IO.puts("\nTesting #{config.provider} models:")
+          Enum.map(config.models, fn model ->
+            run_test(config.provider, model, [api_key: api_key])
+          end)
+      end
+    end)
+
+    IO.puts("\n" <> String.duplicate("=", 30))
+    IO.puts("Results Summary:")
+
+    passed = Enum.count(results, fn {status, _} -> status == :correct end)
+    failed = Enum.count(results, fn {status, _} -> status in [:incorrect, :error] end)
+    skipped = Enum.count(results, fn {status, _} -> status == :skip end)
+
+    IO.puts("  Passed: #{passed}")
+    IO.puts("  Failed: #{failed}")
+    IO.puts("  Skipped: #{skipped}")
+
+    results
+  end
+end
+
+# Run all tests
+Demo.run_all_tests()
+
+
+# parts: [%{text: prompt}]

--- a/lib/instructor_lite/gemini_json.ex
+++ b/lib/instructor_lite/gemini_json.ex
@@ -1,0 +1,181 @@
+defmodule InstructorLite.GeminiJSON do
+  @moduledoc """
+  Helper module to convert Ecto schemas to Gemini-compatible JSON schemas.
+  
+  Gemini's JSON schema format differs from standard JSON Schema in several ways:
+  - Based on OpenAPI 3.0 schema subset
+  - All fields in 'required' array must exist in properties
+  - No support for union types or conditionals
+  - Limited support for nested schemas
+  
+  ## Example
+  
+      iex> GeminiJSON.from_ecto_schema(UserInfo)
+      %{
+        type: "object",
+        required: [:name, :age],
+        properties: %{
+          name: %{type: "string"},
+          age: %{type: "integer"}
+        }
+      }
+  """
+
+  @doc """
+  Converts an Ecto schema module to a Gemini-compatible JSON schema.
+  
+  Raises an error if the schema contains unsupported field types.
+  """
+  def from_ecto_schema(ecto_schema) when is_atom(ecto_schema) do
+    unless function_exported?(ecto_schema, :__schema__, 1) do
+      raise ArgumentError, """
+      #{inspect(ecto_schema)} is not an Ecto schema module.
+      Expected a module that uses Ecto.Schema.
+      """
+    end
+    
+    fields = ecto_schema.__schema__(:fields)
+    
+    properties = 
+      Enum.reduce(fields, %{}, fn field, acc ->
+        type = ecto_schema.__schema__(:type, field)
+        Map.put(acc, field, convert_type(type, field))
+      end)
+    
+    # Check for embeds (not yet supported)
+    embeds = ecto_schema.__schema__(:embeds)
+    if embeds != [] do
+      raise ArgumentError, """
+      Embedded schemas are not yet supported by GeminiJSON.
+      Schema #{inspect(ecto_schema)} has embedded fields: #{inspect(embeds)}
+      Please use flat schemas or implement custom json_schema/0 callback.
+      """
+    end
+    
+    # Check for associations (not supported)
+    associations = ecto_schema.__schema__(:associations)
+    if associations != [] do
+      raise ArgumentError, """
+      Associations are not supported by GeminiJSON.
+      Schema #{inspect(ecto_schema)} has associations: #{inspect(associations)}
+      Please use embedded schemas or implement custom json_schema/0 callback.
+      """
+    end
+    
+    %{
+      type: "object",
+      required: fields,
+      properties: properties
+    }
+  end
+
+  defp convert_type(type, field) do
+    case type do
+      :string -> 
+        %{type: "string"}
+        
+      :integer -> 
+        %{type: "integer"}
+        
+      :float -> 
+        %{type: "number"}
+        
+      :boolean -> 
+        %{type: "boolean"}
+        
+      :decimal -> 
+        %{type: "number"}
+        
+      :date -> 
+        %{type: "string"}
+        
+      :time -> 
+        %{type: "string"}
+        
+      :time_usec -> 
+        %{type: "string"}
+        
+      :naive_datetime -> 
+        %{type: "string"}
+        
+      :naive_datetime_usec -> 
+        %{type: "string"}
+        
+      :utc_datetime -> 
+        %{type: "string"}
+        
+      :utc_datetime_usec -> 
+        %{type: "string"}
+        
+      {:array, inner_type} ->
+        %{
+          type: "array",
+          items: convert_type(inner_type, field)
+        }
+        
+      :map ->
+        %{
+          type: "object",
+          additionalProperties: %{}
+        }
+        
+      {:map, value_type} ->
+        %{
+          type: "object",
+          additionalProperties: convert_type(value_type, field)
+        }
+        
+      {:parameterized, {Ecto.Enum, %{mappings: mappings}}} ->
+        %{
+          type: "string",
+          enum: Keyword.keys(mappings)
+        }
+        
+      {:parameterized, {Ecto.Embedded, _}} ->
+        raise ArgumentError, """
+        Embedded field '#{field}' is not yet supported by GeminiJSON.
+        Gemini requires flat schemas or you need to implement custom json_schema/0 callback.
+        
+        Consider using a flat structure or manually defining the schema.
+        """
+        
+      :id ->
+        %{type: "integer"}
+        
+      :binary_id ->
+        %{type: "string"}
+        
+      :binary ->
+        %{type: "string"}
+        
+      other ->
+        raise ArgumentError, """
+        Unsupported field type for '#{field}': #{inspect(other)}
+        
+        GeminiJSON currently supports:
+        - Basic types: :string, :integer, :float, :boolean
+        - Date/time types: :date, :time, :naive_datetime, :utc_datetime
+        - Other types: :decimal, :map, {:array, type}, Ecto.Enum
+        
+        For custom types, implement the json_schema/0 callback in your schema module.
+        """
+    end
+  end
+  
+  @doc """
+  Convenience function to be used inline in the demo or other code.
+  
+  ## Example
+  
+      InstructorLite.instruct(
+        params,
+        response_model: UserInfo,
+        json_schema: GeminiJSON.schema(UserInfo),
+        adapter: InstructorLite.Adapters.Gemini,
+        adapter_context: config
+      )
+  """
+  def schema(ecto_schema) do
+    from_ecto_schema(ecto_schema)
+  end
+end


### PR DESCRIPTION
- Create InstructorLite.GeminiJSON module to convert Ecto schemas to Gemini's OpenAPI 3.0-based format
- Modify Gemini adapter to automatically detect and convert auto-generated schemas

And a demo script to verify gemini/openai/anthropic support
